### PR TITLE
Update widget text

### DIFF
--- a/resources/lang/en/images-missing-alt.php
+++ b/resources/lang/en/images-missing-alt.php
@@ -1,10 +1,10 @@
 <?php
 
 return [
-    'title'               => 'Assets without Alt Text',
-    'title-for-container' => 'Assets without Alt Text in :container',
-    'edit'                => 'Edit this Asset',
+    'title'               => 'Images without Alt Text',
+    'title-for-container' => 'Images without Alt Text in :container',
+    'edit'                => 'Edit this image',
     'explanation'         => 'It\'s important to add alt text describing your images. This helps users who depend on assistive technology.',
-    'count'               => '{0}|{1}You have :amount image that need attention.|[2,*]You have at least :amount images that need attention.',
-    'done'                => 'All assets have an alt text.',
+    'count'               => '{0}|{1}You have :amount image that needs attention.|[2,*]You have at least :amount images that need attention.',
+    'done'                => 'All images have an alt text.',
 ];


### PR DESCRIPTION
I've suggested some updates here for improved clarity in the widget. 

Where it's common to have "Assets" as the primary container name, the widget text reads a little awkwardly in places – most notably in the title which renders as "Assets without Alt Text in Test Assets".

These changes should improve the UX slightly to avoid confusion for users, by referring to assets as "images".